### PR TITLE
Better Steam Detection

### DIFF
--- a/Client/Util.cs
+++ b/Client/Util.cs
@@ -148,11 +148,6 @@ namespace FTLOverdrive.Client
                 return progfiles + "/FTL/";
             }
 
-            //return (string)(Microsoft.Win32.RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.CurrentUser, Microsoft.Win32.RegistryView.Default).OpenSubKey("Software").OpenSubKey("Valve").OpenSubKey("Steam").GetValue("SteamExe"));
-
-
-
-
             // Next, locate steam
             string steampath = (string)(Microsoft.Win32.RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.CurrentUser, Microsoft.Win32.RegistryView.Default).OpenSubKey("Software").OpenSubKey("Valve").OpenSubKey("Steam").GetValue("SteamPath"));
             

--- a/Client/Util.cs
+++ b/Client/Util.cs
@@ -140,6 +140,7 @@ namespace FTLOverdrive.Client
         {
             // First, locate program files
             string progfiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86).Replace('\\', '/');
+              
             if (!Directory.Exists(progfiles + "/")) return null;
 
             if (Directory.Exists(progfiles + "/FTL/"))
@@ -147,14 +148,21 @@ namespace FTLOverdrive.Client
                 return progfiles + "/FTL/";
             }
 
+            //return (string)(Microsoft.Win32.RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.CurrentUser, Microsoft.Win32.RegistryView.Default).OpenSubKey("Software").OpenSubKey("Valve").OpenSubKey("Steam").GetValue("SteamExe"));
+
+
+
+
             // Next, locate steam
-            if (!Directory.Exists(progfiles + "/Steam/")) return null;
+            string steampath = (string)(Microsoft.Win32.RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.CurrentUser, Microsoft.Win32.RegistryView.Default).OpenSubKey("Software").OpenSubKey("Valve").OpenSubKey("Steam").GetValue("SteamPath"));
+            
+            if (!Directory.Exists(steampath)) return null;
 
             // Next, locate FTL
-            if (!Directory.Exists(progfiles + "/Steam/steamapps/common/FTL Faster Than Light/")) return null;
+            if (!Directory.Exists(steampath + "/steamapps/common/FTL Faster Than Light/")) return null;
 
             // Done
-            return progfiles + "/Steam/steamapps/common/FTL Faster Than Light/";
+            return steampath + "/steamapps/common/FTL Faster Than Light/";
         }
 
     }


### PR DESCRIPTION
Instead of attempting to locate Steam through Program Files, it uses the
Registry Key for Steam's Path, which is added automatically upon
installation of Steam, regardless of install location.
This is useful for those who decide to install Steam in different
locations, such as a secondary Hard Drive.
